### PR TITLE
Add nfc support for android.

### DIFF
--- a/android/src/main/java/name/avioli/unilinks/UniLinksPlugin.java
+++ b/android/src/main/java/name/avioli/unilinks/UniLinksPlugin.java
@@ -3,6 +3,8 @@ package name.avioli.unilinks;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.nfc.NfcAdapter;
+
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
@@ -54,8 +56,7 @@ public class UniLinksPlugin
   private void handleIntent(Context context, Intent intent, Boolean initial) {
     String action = intent.getAction();
     String dataString = intent.getDataString();
-
-    if (Intent.ACTION_VIEW.equals(action)) {
+	if (Intent.ACTION_VIEW.equals(action) || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)) {
       if (initial) initialLink = dataString;
       latestLink = dataString;
       if (changeReceiver != null) changeReceiver.onReceive(context, intent);


### PR DESCRIPTION
We're currently trying to test NFC with the Natrium wallet and found that URIs are not forwarded.
Proposal to add NFC support for android, as per the android docs:

https://developer.android.com/reference/android/nfc/NfcAdapter.html#ACTION_NDEF_DISCOVERED

"Intent to start an activity when a tag with NDEF payload is discovered.

The system inspects the first NdefRecord in the first NdefMessage and looks for a URI, SmartPoster, or MIME record. If a URI or SmartPoster record is found the intent will contain the **URI in its data field.**"

This change works nicely with the current uni_links implementation (Have built and tested with a URI sent over NFC). But there may be extra work to be done, could do with some advice. (I'm not a mobile dev)

I'm not sure how iOS behaves as I don't have access to an iPhone, there may be some work to do there to keep things consistent.

@bbedward if this change gets approved would it be possible to include this in Natrium at some point? It makes it quite simple to pass URIs over NFC.