### PR TITLE
Migrate to Flutter 2

### DIFF
--- a/uni_links/example/pubspec.yaml
+++ b/uni_links/example/pubspec.yaml
@@ -6,7 +6,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.1 <3.0.0"
 
 dependencies:
   flutter:

--- a/uni_links/pubspec.yaml
+++ b/uni_links/pubspec.yaml
@@ -12,11 +12,11 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.3
+  pedantic: ^1.11.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.1 <3.0.0"
 
 flutter:
   plugin:

--- a/uni_links_platform_interface/pubspec.yaml
+++ b/uni_links_platform_interface/pubspec.yaml
@@ -6,13 +6,13 @@ homepage: https://github.com/avioli/uni_links/tree/master/uni_links_platform_int
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.3
+  pedantic: ^1.11.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.1 <3.0.0"

--- a/uni_links_web/pubspec.yaml
+++ b/uni_links_web/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.3
+  pedantic: ^1.11.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.1 <3.0.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
I propose this PR to migrate the plugin to Flutter 2 framework so null safety is recognized when using the dependencies. I think this was the only thing to do in order for the plugin to be recognized as "Null safe" in pub.dev as you already migrated to Dart 2.12+ and all code was already null safe (thanks for the awesome job 🎉 ).

Note that I've updated pedantic package which new version is now null safe by default.

Closes #103 