### PR TITLE
Fix for getInitialLink returning null issue when cold-starting iOS app from a push notification [iOS ONLY]

### DIFF
--- a/uni_links/ios/Classes/UniLinksPlugin.m
+++ b/uni_links/ios/Classes/UniLinksPlugin.m
@@ -81,7 +81,7 @@ static id _instance;
       result(self.initialLink);
     } else if(self.latestLink) {
       result(self.latestLink);
-    } else result(FlutterMethodNotImplemented);
+    } result(nil);
     // } else if ([@"getLatestLink" isEqualToString:call.method]) {
     //     result(self.latestLink);
   } else {

--- a/uni_links/ios/Classes/UniLinksPlugin.m
+++ b/uni_links/ios/Classes/UniLinksPlugin.m
@@ -80,7 +80,7 @@ static id _instance;
     if(self.initialLink) {
       result(self.initialLink);
     } else if(self.latestLink) {
-      result(self.initialLink);
+      result(self.latestLink);
     } else result(FlutterMethodNotImplemented);
     // } else if ([@"getLatestLink" isEqualToString:call.method]) {
     //     result(self.latestLink);

--- a/uni_links/ios/Classes/UniLinksPlugin.m
+++ b/uni_links/ios/Classes/UniLinksPlugin.m
@@ -77,7 +77,11 @@ static id _instance;
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([@"getInitialLink" isEqualToString:call.method]) {
-    result(self.initialLink);
+    if(self.initialLink) {
+      result(self.initialLink);
+    } else if(self.latestLink) {
+      result(self.initialLink);
+    } else result(FlutterMethodNotImplemented);
     // } else if ([@"getLatestLink" isEqualToString:call.method]) {
     //     result(self.latestLink);
   } else {


### PR DESCRIPTION
To give some context: 
We have a Flutter app utilizing uni_links for handling custom scheme-based deeplinks into the app, and we're using Braze for CRM. Push notifications worked just fine when the app was in foreground or background. However, only when tapping a PN resulted in cold-starting the app, getInitialLink kept returning null*. After debugging with Xcode, we noticed that getInitialLink got invoked twice, first time both "initialLink" and "latestLink" were pointing to the deeplinked url, but the second time only "latestLink" was. But "initialLink" was the one always passed back to Flutter. We were able to fix the issue with this solution, but there could be better way to keep this double invocation from happening in the first place.

* When tapping a link received in a message for example, getInitialLink returned the link just right.