### PR TITLE
Migrate from Jcenter to Maven Central

### DIFF
--- a/uni_links/android/build.gradle
+++ b/uni_links/android/build.gradle
@@ -4,7 +4,7 @@ version '0.4.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Following as Jcenter shutting down.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/