### PR TITLE
Wasm support Flutter 3.22.0 or higher

### DIFF
--- a/uni_links/example/lib/main.dart
+++ b/uni_links/example/lib/main.dart
@@ -24,8 +24,8 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
 
   final _scaffoldKey = GlobalKey();
   final _cmds = getCmds();
-  final _cmdStyle = const TextStyle(
-      fontFamily: 'Courier', fontSize: 12.0, fontWeight: FontWeight.w700);
+  final _cmdStyle =
+      const TextStyle(fontFamily: 'Courier', fontSize: 12.0, fontWeight: FontWeight.w700);
 
   @override
   void initState() {
@@ -196,7 +196,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
               '(tap on any of the above commands to print it to'
               ' the console/logger and copy to the device clipboard.)',
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.caption,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
           ]
         ].expand((el) => el).toList(),
@@ -222,7 +222,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   }
 
   void _showSnackBar(String msg) {
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       final context = _scaffoldKey.currentContext;
       if (context != null) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/uni_links/example/pubspec.yaml
+++ b/uni_links/example/pubspec.yaml
@@ -6,15 +6,11 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
 
   uni_links:
     path: ../

--- a/uni_links/pubspec.yaml
+++ b/uni_links/pubspec.yaml
@@ -14,8 +14,7 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.0"
+  sdk: '>=3.4.0 <4.0.0'
 
 flutter:
   plugin:

--- a/uni_links_platform_interface/pubspec.yaml
+++ b/uni_links_platform_interface/pubspec.yaml
@@ -13,5 +13,4 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.0"
+  sdk: '>=3.4.0 <4.0.0'

--- a/uni_links_web/lib/uni_links_web.dart
+++ b/uni_links_web/lib/uni_links_web.dart
@@ -1,5 +1,4 @@
-import 'dart:html';
-
+import 'package:web/web.dart' as web;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:uni_links_platform_interface/uni_links_platform_interface.dart';
 
@@ -10,7 +9,7 @@ class UniLinksPlugin extends UniLinksPlatform {
 
   /// The Web URL is stored here on startup, as it's prone to changing
   /// throughout the app's lifetime.
-  final _initialLink = window.location.href;
+  final _initialLink = web.window.location.href;
 
   @override
   Future<String?> getInitialLink() async => _initialLink;

--- a/uni_links_web/lib/uni_links_web.dart
+++ b/uni_links_web/lib/uni_links_web.dart
@@ -1,4 +1,4 @@
-import 'package:web/web.dart' as web;
+import 'package:universal_web/web.dart' as web;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:uni_links_platform_interface/uni_links_platform_interface.dart';
 

--- a/uni_links_web/pubspec.yaml
+++ b/uni_links_web/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   uni_links_platform_interface: ^1.0.0
-  web: 0.5.1
+  web: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/uni_links_web/pubspec.yaml
+++ b/uni_links_web/pubspec.yaml
@@ -9,14 +9,14 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   uni_links_platform_interface: ^1.0.0
+  web: 0.5.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  sdk: '>=3.4.0 <4.0.0'
 
 flutter:
   plugin:

--- a/uni_links_web/pubspec.yaml
+++ b/uni_links_web/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   uni_links_platform_interface: ^1.0.0
-  web: ^1.0.0
+  universal_web: ^1.1.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Replaced `dart:html` usage with [package:web](https://pub.dev/packages/web) 